### PR TITLE
商品詳細表示機能実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,6 @@ class ApplicationController < ActionController::Base
   before_action :basic_auth
   before_action :configure_permitted_parameters, if: :devise_controller?
 
-
   private
 
   def basic_auth
@@ -12,6 +11,7 @@ class ApplicationController < ActionController::Base
   end
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname,:first_name,:last_name,:first_name_kana,:last_name_kana,:birth_day])
+    devise_parameter_sanitizer.permit(:sign_up,
+                                      keys: [:nickname, :first_name, :last_name, :first_name_kana, :last_name_kana, :birth_day])
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -18,6 +18,10 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+    @item = Item.find(params[:id])
+  end
+
  private
 
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,8 +1,8 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user! , only: [:new]
+  before_action :authenticate_user!, only: [:new]
 
   def index
-    @items = Item.includes(:user).order("created_at DESC")
+    @items = Item.includes(:user).order('created_at DESC')
   end
 
   def new
@@ -11,7 +11,7 @@ class ItemsController < ApplicationController
 
   def create
     @item = Item.create(item_params)
-    if  @item.save
+    if @item.save
       redirect_to root_path
     else
       render :new
@@ -22,10 +22,10 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
   end
 
- private
+  private
 
   def item_params
-    params.require(:item).permit(:image,:name,:descriptions,:category_id,:status_id,:delivery_fee_id,:delivery_area_id,:delivery_day_id,:price).merge(user_id: current_user.id)
+    params.require(:item).permit(:image, :name, :descriptions, :category_id, :status_id, :delivery_fee_id, :delivery_area_id,
+                                 :delivery_day_id, :price).merge(user_id: current_user.id)
   end
-  
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -12,9 +12,8 @@ class Category < ActiveHash::Base
     { id: 10, name: 'ハンドメイド' },
     { id: 11, name: 'その他' }
   ]
-  
+
   include ActiveHash::Associations
 
   has_many :items
 end
-

--- a/app/models/delivery_area.rb
+++ b/app/models/delivery_area.rb
@@ -47,10 +47,9 @@ class DeliveryArea < ActiveHash::Base
     { id: 45, name: '大分県' },
     { id: 46, name: '宮崎県' },
     { id: 47, name: '鹿児島県' },
-    { id: 48, name: '沖縄県' },
+    { id: 48, name: '沖縄県' }
   ]
-
 
   include ActiveHash::Associations
   has_many :items
-  end
+end

--- a/app/models/delivery_day.rb
+++ b/app/models/delivery_day.rb
@@ -3,9 +3,9 @@ class DeliveryDay < ActiveHash::Base
     { id: 1, name: '--' },
     { id: 2, name: '1〜2日で発送' },
     { id: 3, name: '2〜3日で発送' },
-    { id: 4, name: '4〜7日で発送' },
+    { id: 4, name: '4〜7日で発送' }
   ]
 
   include ActiveHash::Associations
   has_many :items
-  end
+end

--- a/app/models/delivery_fee.rb
+++ b/app/models/delivery_fee.rb
@@ -2,9 +2,9 @@ class DeliveryFee < ActiveHash::Base
   self.data = [
     { id: 1, name: '--' },
     { id: 2, name: '着払い（購入者負担）' },
-    { id: 3, name: '送料込み（出品者負担）' },
+    { id: 3, name: '送料込み（出品者負担）' }
   ]
 
   include ActiveHash::Associations
   has_many :items
-  end
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,10 +1,10 @@
 class Item < ApplicationRecord
-
   has_one_attached :image
 
   belongs_to :user
 
-  validates :price, presence: true, format: { with: /\A[0-9][\d]+\z/, message: ' Half-width number' } ,numericality: {greater_than_or_equal_to: 300, less_than_or_equal_to: 9999999, message: "Price Out of setting range"}
+  validates :price, presence: true, format: { with: /\A[0-9]\d+\z/, message: ' Half-width number' },
+                    numericality: { greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999, message: 'Price Out of setting range' }
 
   with_options presence: true do
     validates :name

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -6,10 +6,9 @@ class Status < ActiveHash::Base
     { id: 4, name: '目立った傷や汚れなし' },
     { id: 5, name: 'やや傷や汚れあり' },
     { id: 6, name: '傷や汚れあり' },
-    { id: 7, name: '全体的に状態が悪い' },
+    { id: 7, name: '全体的に状態が悪い' }
   ]
-
 
   include ActiveHash::Associations
   has_many :items
-  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,14 +3,13 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
-  
+
   has_many :items
 
   with_options presence: true do
     validates :nickname
     validates :birth_day
   end
-  
 
   with_options presence: true, format: { with: /\A[ァ-ヶ]+\z/, message: 'Full-width katakana characters' } do
     validates :first_name_kana
@@ -22,7 +21,6 @@ class User < ApplicationRecord
     validates :last_name
   end
 
-  PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?[\d])[a-z\d]+\z/i.freeze
-    validates_format_of :password, with: PASSWORD_REGEX, message: 'Include both letters and numbers' 
+  PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i.freeze
+  validates_format_of :password, with: PASSWORD_REGEX, message: 'Include both letters and numbers'
 end
-

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,7 +128,7 @@
 
       <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to item_path(item) do %>
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %>
 

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -132,11 +132,11 @@
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %>
 
-          <%# if item.user == nil %>
-          <div class='sold-out'>
+          <% if @item  != nil %>
+           <div class='sold-out'>
             <span>Sold Out!!</span>
-          </div>
-          <%# end %>
+           </div>
+          <% end %>
 
         </div>
         <div class='item-info'>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -132,11 +132,11 @@
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %>
 
-          <% if item.nil? %>
+          <%# if item.nil? %>
            <div class='sold-out'>
             <span>Sold Out!!</span>
            </div>
-          <% end %>
+          <%# end %>
 
         </div>
         <div class='item-info'>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -132,7 +132,7 @@
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %>
 
-          <% if @item  != nil %>
+          <% if item.nil? %>
            <div class='sold-out'>
             <span>Sold Out!!</span>
            </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -9,9 +9,11 @@
     <div class="item-img-content">
       <%= image_tag @item.image ,class:"item-box-img" if @item.image.attached? %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
+      <% if @item.nil? %>
       <div class="sold-out">
         <span>Sold Out!!</span>
       </div>
+      <% end %>
       <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">
@@ -28,7 +30,7 @@
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-   <% elsif @item != nil %>
+   <% elsif  @item != nil %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
     <% end %>
   <% end %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -8,20 +8,20 @@
     </h2>
     <div class="item-img-content">
       <%= image_tag @item.image ,class:"item-box-img" if @item.image.attached? %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
+      
       <% if @item.nil? %>
       <div class="sold-out">
         <span>Sold Out!!</span>
       </div>
       <% end %>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
+      
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= @item.price %>
       </span>
       <span class="item-postage">
-        <%= "item.delivery_fee.name" %>
+        <%= @item.delivery_fee.name %>
       </span>
     </div>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -9,11 +9,11 @@
     <div class="item-img-content">
       <%= image_tag @item.image ,class:"item-box-img" if @item.image.attached? %>
       
-      <% if @item.nil? %>
+      <%# if @item.nil? %>
       <div class="sold-out">
         <span>Sold Out!!</span>
       </div>
-      <% end %>
+      <%# end %>
       
     </div>
     <div class="item-price-box">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -23,15 +23,19 @@
       </span>
     </div>
 
-  
+  <% if user_signed_in? %>  
+   <% if current_user.id == @item.user_id %>  
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+   <% elsif @item != nil %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
- 
+    <% end %>
+  <% end %>
 
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-  
+
+
     <div class="item-explain-box">
       <span><%= @item.descriptions %></span>
     </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -104,8 +104,8 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+ 
+  <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
+  
 </div>
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,0 +1,105 @@
+<%= render "shared/header" %>
+
+<%# 商品の概要 %>
+<div class="item-show">
+  <div class="item-box">
+    <h2 class="name">
+      <%= @item.name %>
+    </h2>
+    <div class="item-img-content">
+      <%= image_tag @item.image ,class:"item-box-img" if @item.image.attached? %>
+      <%# 商品が売れている場合は、sold outを表示しましょう %>
+      <div class="sold-out">
+        <span>Sold Out!!</span>
+      </div>
+      <%# //商品が売れている場合は、sold outを表示しましょう %>
+    </div>
+    <div class="item-price-box">
+      <span class="item-price">
+        ¥ 999,999,999
+      </span>
+      <span class="item-postage">
+        <%= "item.delivery_fee.name" %>
+      </span>
+    </div>
+
+  
+    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+    <p class="or-text">or</p>
+    <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+ 
+
+    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+  
+    <div class="item-explain-box">
+      <span><%= @item.descriptions %></span>
+    </div>
+    <table class="detail-table">
+      <tbody>
+        <tr>
+          <th class="detail-item">出品者</th>
+          <td class="detail-value"><%= @item.user.nickname %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">カテゴリー</th>
+          <td class="detail-value"><%= @item.category.name %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">商品の状態</th>
+          <td class="detail-value"><%= @item.status.name %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">配送料の負担</th>
+          <td class="detail-value"><%= @item.delivery_fee.name %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">発送元の地域</th>
+          <td class="detail-value"><%= @item.delivery_area.name %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">発送日の目安</th>
+          <td class="detail-value"><%= @item.delivery_day.name %></td>
+        </tr>
+      </tbody>
+    </table>
+    <div class="option">
+      <div class="favorite-btn">
+        <%= image_tag "star.png" ,class:"favorite-star-icon" ,width:"20",height:"20"%>
+        <span>お気に入り 0</span>
+      </div>
+      <div class="report-btn">
+        <%= image_tag "flag.png" ,class:"report-flag-icon" ,width:"20",height:"20"%>
+        <span>不適切な商品の通報</span>
+      </div>
+    </div>
+  </div>
+  <%# /商品の概要 %>
+
+  <div class="comment-box">
+    <form>
+      <textarea class="comment-text"></textarea>
+      <p class="comment-warn">
+        相手のことを考え丁寧なコメントを心がけましょう。
+        <br>
+        不快な言葉遣いなどは利用制限や退会処分となることがあります。
+      </p>
+      <button type="submit" class="comment-btn">
+        <%= image_tag "comment.png" ,class:"comment-flag-icon" ,width:"20",height:"25"%>
+        <span>コメントする<span>
+      </button>
+    </form>
+  </div>
+  <div class="links">
+    <a href="#" class="change-item-btn">
+      ＜ 前の商品
+    </a>
+    <a href="#" class="change-item-btn">
+      後ろの商品 ＞
+    </a>
+  </div>
+  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+</div>
+<%= render "shared/footer" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items, only: [:index, :new, :create]
+  resources :items, only: [:index, :new, :create, :show]
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,15 +1,15 @@
 FactoryBot.define do
   factory :item do
-    name             {Faker::Lorem.sentence}
-    descriptions     {Faker::Lorem.sentence}
-    category_id      {2}
-    status_id        {2}
-    delivery_fee_id  {2}
-    delivery_area_id {2}
-    delivery_day_id  {2}
-    price            {300}
+    name             { Faker::Lorem.sentence }
+    descriptions     { Faker::Lorem.sentence }
+    category_id      { 2 }
+    status_id        { 2 }
+    delivery_fee_id  { 2 }
+    delivery_area_id { 2 }
+    delivery_day_id  { 2 }
+    price            { 300 }
 
-    association :user 
+    association :user
 
     after(:build) do |item|
       item.image.attach(io: File.open('public/images/test_image.png'), filename: 'test_image.png')

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,13 +1,13 @@
 FactoryBot.define do
   factory :user do
-    nickname              {Faker::Name.name}
-    email                 {Faker::Internet.free_email}
-    password              {"000aaa"}
-    password_confirmation {password}
-    last_name             {"姓"}
-    first_name            {"名"}
-    last_name_kana        {"セイ"}
-    first_name_kana       {"メイ"}
-    birth_day             {"2000-01-01"}
+    nickname              { Faker::Name.name }
+    email                 { Faker::Internet.free_email }
+    password              { '000aaa' }
+    password_confirmation { password }
+    last_name             { '姓' }
+    first_name            { '名' }
+    last_name_kana        { 'セイ' }
+    first_name_kana       { 'メイ' }
+    birth_day             { '2000-01-01' }
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -6,31 +6,28 @@ RSpec.describe Item, type: :model do
   end
 
   describe '商品情報の保存' do
-
     context '商品が出品できる場合' do
       it 'image,name,description,caetgory_id,status_id,delivery_fee_id,delivery_area_id,delivery_day_id,priceがあれば出品できる' do
         expect(@item).to be_valid
       end
 
-      it'priceは、¥300以上なら保存可能であること'do
+      it 'priceは、¥300以上なら保存可能であること' do
         @item.price = '300'
         expect(@item).to be_valid
       end
 
-      it'priceは、¥9,999,999以下なら保存可能であること'do
+      it 'priceは、¥9,999,999以下なら保存可能であること' do
         @item.price = '9999999'
         expect(@item).to be_valid
       end
 
-      it'priceは、半角英数のみ保存可能であること'do
+      it 'priceは、半角英数のみ保存可能であること' do
         @item.price = '1111'
         expect(@item).to be_valid
       end
-
     end
 
     context '商品が出品できない場合' do
-
       it 'imageが空では登録できないこと' do
         @item.image = nil
         @item.valid?
@@ -52,101 +49,99 @@ RSpec.describe Item, type: :model do
       it 'category_idが空では登録できないこと' do
         @item.category_id = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include("Category is not a number")
+        expect(@item.errors.full_messages).to include('Category is not a number')
       end
 
       it 'status_idが空では登録できないこと' do
         @item.status_id = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include("Status is not a number")
+        expect(@item.errors.full_messages).to include('Status is not a number')
       end
 
       it 'delivery_fee_idが空では登録できないこと' do
         @item.delivery_fee_id = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include("Delivery fee is not a number")
+        expect(@item.errors.full_messages).to include('Delivery fee is not a number')
       end
 
       it 'delivery_area_idが空では登録できないこと' do
         @item.delivery_area_id = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include("Delivery area is not a number")
+        expect(@item.errors.full_messages).to include('Delivery area is not a number')
       end
 
       it 'delivery_day_idが空では登録できないこと' do
         @item.delivery_day_id = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include("Delivery day is not a number")
+        expect(@item.errors.full_messages).to include('Delivery day is not a number')
       end
 
       it 'priceが空では登録できないこと' do
         @item.price = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price can't be blank", "Price  Half-width number", "Price Price Out of setting range")
+        expect(@item.errors.full_messages).to include("Price can't be blank", 'Price  Half-width number',
+                                                      'Price Price Out of setting range')
       end
 
       it 'category_idが -- では登録できないこと' do
         @item.category_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Category must be other than 1")
+        expect(@item.errors.full_messages).to include('Category must be other than 1')
       end
 
       it 'status_idが -- では登録できないこと' do
         @item.status_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Status must be other than 1")
+        expect(@item.errors.full_messages).to include('Status must be other than 1')
       end
 
       it 'delivery_fee_idが -- では登録できないこと' do
         @item.delivery_fee_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Delivery fee must be other than 1")
+        expect(@item.errors.full_messages).to include('Delivery fee must be other than 1')
       end
 
       it 'delivery_area_idが -- では登録できないこと' do
         @item.delivery_area_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Delivery area must be other than 1")
+        expect(@item.errors.full_messages).to include('Delivery area must be other than 1')
       end
 
       it 'delivery_day_idが -- では登録できないこと' do
         @item.delivery_day_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Delivery day must be other than 1")
+        expect(@item.errors.full_messages).to include('Delivery day must be other than 1')
       end
 
-      it'priceは、¥300未満なら保存できないこと'do
+      it 'priceは、¥300未満なら保存できないこと' do
         @item.price = 299
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price Price Out of setting range")
+        expect(@item.errors.full_messages).to include('Price Price Out of setting range')
       end
 
-      it'priceは、¥10000000以上なら保存できないこと'do
-        @item.price = 10000000
+      it 'priceは、¥10000000以上なら保存できないこと' do
+        @item.price = 10_000_000
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price Price Out of setting range")
+        expect(@item.errors.full_messages).to include('Price Price Out of setting range')
       end
 
-      it'priceは、半角英語では保存できないこと'do
+      it 'priceは、半角英語では保存できないこと' do
         @item.price = 'aaaa'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price Price Out of setting range")
+        expect(@item.errors.full_messages).to include('Price Price Out of setting range')
       end
 
-      it'priceは、全角数字では保存できないこと'do
+      it 'priceは、全角数字では保存できないこと' do
         @item.price = '１０００'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price Price Out of setting range")
+        expect(@item.errors.full_messages).to include('Price Price Out of setting range')
       end
 
-      it'priceは、全角英語では保存できないこと'do
+      it 'priceは、全角英語では保存できないこと' do
         @item.price = 'ＡＡＡＡ'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price Price Out of setting range")
+        expect(@item.errors.full_messages).to include('Price Price Out of setting range')
       end
-
-
     end
   end
 end
-

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  describe "ユーザー新規登録" do
+  describe 'ユーザー新規登録' do
     before do
       @user = FactoryBot.build(:user)
     end
@@ -25,7 +25,6 @@ RSpec.describe User, type: :model do
     end
 
     context '新規登録できないとき' do
-
       it 'nicknameが空では登録できないこと' do
         @user.nickname = ''
         @user.valid?
@@ -37,36 +36,35 @@ RSpec.describe User, type: :model do
         @user.valid?
         expect(@user.errors.full_messages).to include("Email can't be blank")
       end
-  
+
       it 'passwordが空では登録できないこと' do
         @user.password = ''
         @user.valid?
         expect(@user.errors.full_messages).to include("Password can't be blank")
       end
 
-      
       it 'last_nameが空では登録できないこと' do
         @user.last_name = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Last name Full-width characters")
+        expect(@user.errors.full_messages).to include('Last name Full-width characters')
       end
 
       it 'first_nameが空では登録できないこと' do
         @user.first_name = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("First name Full-width characters")
+        expect(@user.errors.full_messages).to include('First name Full-width characters')
       end
 
       it 'last_name_kanaが空では登録できないこと' do
         @user.last_name_kana = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Last name kana Full-width katakana characters")
+        expect(@user.errors.full_messages).to include('Last name kana Full-width katakana characters')
       end
 
       it 'first_name_kanaが空では登録できないこと' do
         @user.first_name_kana = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("First name kana Full-width katakana characters")
+        expect(@user.errors.full_messages).to include('First name kana Full-width katakana characters')
       end
 
       it 'birth_dayが空では登録できないこと' do
@@ -82,42 +80,42 @@ RSpec.describe User, type: :model do
         expect(@user.errors.full_messages).to include('Password is too short (minimum is 6 characters)')
       end
 
-      it 'passwordは半角数字のみでは登録できない'do
+      it 'passwordは半角数字のみでは登録できない' do
         @user.password = '111111'
         @user.password_confirmation = '111111'
         @user.valid?
         expect(@user.errors.full_messages).to include('Password Include both letters and numbers')
       end
 
-      it 'passwordは半角英語のみでは登録できない'do
+      it 'passwordは半角英語のみでは登録できない' do
         @user.password = 'aaaaaa'
         @user.password_confirmation = 'aaaaaa'
         @user.valid?
         expect(@user.errors.full_messages).to include('Password Include both letters and numbers')
       end
 
-      it 'last_nameは全角でなければ登録できない'do
+      it 'last_nameは全角でなければ登録できない' do
         @user.last_name = 'aa'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Last name Full-width characters")
+        expect(@user.errors.full_messages).to include('Last name Full-width characters')
       end
 
-      it 'first_nameは全角でなければ登録できない'do
+      it 'first_nameは全角でなければ登録できない' do
         @user.first_name = 'aa'
         @user.valid?
-        expect(@user.errors.full_messages).to include("First name Full-width characters")
+        expect(@user.errors.full_messages).to include('First name Full-width characters')
       end
 
-      it 'last_name_kanaは全角でなければ登録できない'do
+      it 'last_name_kanaは全角でなければ登録できない' do
         @user.last_name_kana = 'aa'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Last name kana Full-width katakana characters")
+        expect(@user.errors.full_messages).to include('Last name kana Full-width katakana characters')
       end
 
-      it 'first_name_kanaは全角でなければ登録できない'do
+      it 'first_name_kanaは全角でなければ登録できない' do
         @user.first_name_kana = 'aa'
         @user.valid?
-        expect(@user.errors.full_messages).to include("First name kana Full-width katakana characters")
+        expect(@user.errors.full_messages).to include('First name kana Full-width katakana characters')
       end
 
       it 'passwordが存在してもpassword_confirmationが空では登録できない' do
@@ -140,13 +138,11 @@ RSpec.describe User, type: :model do
         expect(another_user.errors.full_messages).to include('Email has already been taken')
       end
 
-      it 'emailに@がないと登録できないこと'do
+      it 'emailに@がないと登録できないこと' do
         @user.email = 'test.com'
         @user.valid?
         expect(@user.errors.full_messages).to include('Email is invalid')
-      end  
-
-
-   end
- end
+      end
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
-abort("The Rails environment is running in production mode!") if Rails.env.production?
+abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,53 +44,51 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
-=begin
-  # This allows you to limit a spec run to individual examples or groups
-  # you care about by tagging them with `:focus` metadata. When nothing
-  # is tagged with `:focus`, all examples get run. RSpec also provides
-  # aliases for `it`, `describe`, and `context` that include `:focus`
-  # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
-  config.filter_run_when_matching :focus
-
-  # Allows RSpec to persist some state between runs in order to support
-  # the `--only-failures` and `--next-failure` CLI options. We recommend
-  # you configure your source control system to ignore this file.
-  config.example_status_persistence_file_path = "spec/examples.txt"
-
-  # Limits the available syntax to the non-monkey patched syntax that is
-  # recommended. For more details, see:
-  #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
-  #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
-  #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
-  config.disable_monkey_patching!
-
-  # Many RSpec users commonly either run the entire suite or an individual
-  # file, and it's useful to allow more verbose output when running an
-  # individual spec file.
-  if config.files_to_run.one?
-    # Use the documentation formatter for detailed output,
-    # unless a formatter has already been configured
-    # (e.g. via a command-line flag).
-    config.default_formatter = "doc"
-  end
-
-  # Print the 10 slowest examples and example groups at the
-  # end of the spec run, to help surface which specs are running
-  # particularly slow.
-  config.profile_examples = 10
-
-  # Run specs in random order to surface order dependencies. If you find an
-  # order dependency and want to debug it, you can fix the order by providing
-  # the seed, which is printed after each run.
-  #     --seed 1234
-  config.order = :random
-
-  # Seed global randomization in this process using the `--seed` CLI option.
-  # Setting this allows you to use `--seed` to deterministically reproduce
-  # test failures related to randomization by passing the same `--seed` value
-  # as the one that triggered the failure.
-  Kernel.srand config.seed
-=end
+  # The settings below are suggested to provide a good initial experience
+  # with RSpec, but feel free to customize to your heart's content.
+  #   # This allows you to limit a spec run to individual examples or groups
+  #   # you care about by tagging them with `:focus` metadata. When nothing
+  #   # is tagged with `:focus`, all examples get run. RSpec also provides
+  #   # aliases for `it`, `describe`, and `context` that include `:focus`
+  #   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
+  #   config.filter_run_when_matching :focus
+  #
+  #   # Allows RSpec to persist some state between runs in order to support
+  #   # the `--only-failures` and `--next-failure` CLI options. We recommend
+  #   # you configure your source control system to ignore this file.
+  #   config.example_status_persistence_file_path = "spec/examples.txt"
+  #
+  #   # Limits the available syntax to the non-monkey patched syntax that is
+  #   # recommended. For more details, see:
+  #   #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
+  #   #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
+  #   #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
+  #   config.disable_monkey_patching!
+  #
+  #   # Many RSpec users commonly either run the entire suite or an individual
+  #   # file, and it's useful to allow more verbose output when running an
+  #   # individual spec file.
+  #   if config.files_to_run.one?
+  #     # Use the documentation formatter for detailed output,
+  #     # unless a formatter has already been configured
+  #     # (e.g. via a command-line flag).
+  #     config.default_formatter = "doc"
+  #   end
+  #
+  #   # Print the 10 slowest examples and example groups at the
+  #   # end of the spec run, to help surface which specs are running
+  #   # particularly slow.
+  #   config.profile_examples = 10
+  #
+  #   # Run specs in random order to surface order dependencies. If you find an
+  #   # order dependency and want to debug it, you can fix the order by providing
+  #   # the seed, which is printed after each run.
+  #   #     --seed 1234
+  #   config.order = :random
+  #
+  #   # Seed global randomization in this process using the `--seed` CLI option.
+  #   # Setting this allows you to use `--seed` to deterministically reproduce
+  #   # test failures related to randomization by passing the same `--seed` value
+  #   # as the one that triggered the failure.
+  #   Kernel.srand config.seed
 end


### PR DESCRIPTION
# what
商品出品時に登録した情報表示
ログイン状態によってボタン表示変更
売却済みの商品は、画像上に「sold out」の文字が表示
# why
商品詳細表示機能実装のため
# 機能動画
・ログイン状態の出品者が、自身の出品した販売中商品の詳細ページへ遷移
     https://gyazo.com/2a37746f3a7f3f9f5e99e7d5fe2003aa
・ログイン状態の出品者以外のユーザーが、他者の出品した販売中商品の詳細ページへ遷移
     https://gyazo.com/81a1eb2b1254887a43b3ff45e6c99ada
・ログアウト状態のユーザーが、商品詳細ページへ遷移
     https://gyazo.com/3dec6a9c0d4c313db0d1021d5c06c033