### PR TITLE
商品削除機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :edit, :create, :update]
-  before_action :move_to_index, only: [:edit, :update]
-  before_action :set_item, only:[:show, :edit, :update]
+  before_action :authenticate_user!, only: [:new, :edit, :create, :update, :destroy]
+  before_action :move_to_index, only: [:edit, :update, :destroy]
+  before_action :set_item, only:[:show, :edit, :update, :destroy]
 
   def index
     @items = Item.includes(:user).order('created_at DESC')
@@ -36,6 +36,11 @@ class ItemsController < ApplicationController
     else
       render :edit
     end
+  end
+
+  def destroy
+    @item.destroy
+    redirect_to root_path
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :edit, :create, :update, :destroy]
   before_action :move_to_index, only: [:edit, :update, :destroy]
-  before_action :set_item, only:[:show, :edit, :update, :destroy]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
 
   def index
     @items = Item.includes(:user).order('created_at DESC')

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,9 +27,9 @@
 
   <% if user_signed_in? %>  
    <% if current_user.id == @item.user_id %>  
-    <%= link_to "商品の編集", edit_item_path(@item) , class: "item-red-btn" %>
+    <%= link_to "商品の編集", edit_item_path(@item),method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
-    <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+    <%= link_to "削除", item_path(@item), method: :delete, class:"item-destroy" %>
    <% elsif  @item != nil %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items, only: [:index, :new, :create, :show, :edit, :update]
+  resources :items, only: [:index, :new, :create, :show, :edit, :update, :destroy]
 end


### PR DESCRIPTION
# what
詳細ページ編集
コントローラ定義
# why
削除機能実装のため
# 機能動画
・ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる
https://gyazo.com/dd34314bcf8d68858df8964d77dc9d65